### PR TITLE
Flush the log file after printing.

### DIFF
--- a/lib/log/log.c
+++ b/lib/log/log.c
@@ -66,6 +66,7 @@ void prraw(const char *func, int err, const char *fmt, va_list ap)
 	fprintf(lfile, "%s" , strerror(err));
 done:
 	fprintf(lfile, "\n");
+	fflush(lfile);
 }
 
 void pr(const char *fmt, ...)


### PR DESCRIPTION
Otherwise you don't see the log output with tail -f until after the game quits.
