### PR TITLE
Don't print the seed in lvlgen.

### DIFF
--- a/cmd/lvlgen/lvlgen.c
+++ b/cmd/lvlgen/lvlgen.c
@@ -94,14 +94,11 @@ static void parseargs(int argc, char *argv[])
 
 static void rng(Rng *r)
 {
-	clock_t seed = 0;
+	clock_t seed = time(0) ^ getpid() ^ getpid() << 16;
 
-	if (seedstr) {
+	if (seedstr)
 		seed = strtol(seedstr, NULL, 10);
-	} else {
-		seed = time(0) ^ getpid() ^ getpid() << 16;
-		pr("lvlgen seed = %lu", (unsigned long) seed);
-	}
+
 	rnginit(r, seed);
 }
 


### PR DESCRIPTION
It prints to the terminal and looks like it's sufficient information
to reproduce a pipeline; it's not. It's printed to debug.log anyway by
mid when it outputs the pipeline.

Fixes #34
