### PR TITLE
s/LLONG/LONG/

### DIFF
--- a/cmd/enmgen/enmgen.c
+++ b/cmd/enmgen/enmgen.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 		fatal("usage: enmgen [-s <seed>] <ID>+ <num>");
 
 	long num = strtol(argv[argc-1], NULL, 10);
-	if (num == LLONG_MIN || num == LLONG_MAX)
+	if (num == LONG_MIN || num == LONG_MAX)
 			fatal("Invalid number: %s", argv[argc-1]);
 
 	Zone *zn = zoneread(stdin);
@@ -99,7 +99,7 @@ static int idargs(int argc, char *argv[], int *ids[])
 	*ids = xalloc(argc, sizeof(*ids));
 	for (i = 1; i < argc - 1; i++) {
 		long l = strtol(argv[i], NULL, 10);
-		if (l == LLONG_MIN || l == LLONG_MAX)
+		if (l == LONG_MIN || l == LONG_MAX)
 			fatal("Invalid number: %s", argv[i]);
 		(*ids)[i-1] = l;
 	}

--- a/cmd/envgen/envgen.c
+++ b/cmd/envgen/envgen.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 		fatal("%d  usage: envgen <ID>+ <num>", argc);
 
 	long num = strtol(argv[argc-1], NULL, 10);
-	if (num == LLONG_MIN || num == LLONG_MAX)
+	if (num == LONG_MIN || num == LONG_MAX)
 		fatal("Invalid number: %s", argv[argc-1]);
 
 	start = (Rect) { (Point) { Startx * Twidth, Starty * Theight },
@@ -108,7 +108,7 @@ static int idargs(int argc, char *argv[], int *ids[])
 	*ids = xalloc(argc, sizeof(*ids));
 	for (i = 1; i < argc - 1; i++) {
 		long l = strtol(argv[i], NULL, 10);
-		if (l == LLONG_MIN || l == LLONG_MAX)
+		if (l == LONG_MIN || l == LONG_MAX)
 			fatal("Invalid number: %s", argv[i]);
 		(*ids)[i-1] = l;
 	}

--- a/cmd/itmgen/itmgen.c
+++ b/cmd/itmgen/itmgen.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 		fatal("usage: itmgen [-s <seed>] <ID>+ <num>");
 
 	long num = strtol(argv[argc-1], NULL, 10);
-	if (num == LLONG_MIN || num == LLONG_MAX)
+	if (num == LONG_MIN || num == LONG_MAX)
 			fatal("Invalid number: %s", argv[argc-1]);
 
 	Zone *zn = zoneread(stdin);
@@ -99,7 +99,7 @@ static int idargs(int argc, char *argv[], int *ids[])
 	*ids = xalloc(argc, sizeof(*ids));
 	for (i = 1; i < argc - 1; i++) {
 		long l = strtol(argv[i], NULL, 10);
-		if (l == LLONG_MIN || l == LLONG_MAX)
+		if (l == LONG_MIN || l == LONG_MAX)
 			fatal("Invalid number: %s", argv[i]);
 		(*ids)[i-1] = l;
 	}


### PR DESCRIPTION
now using LONG_MIN and LONG_MAX in enmgen.c, envgen.c, and itmgen.c, rather than LLONG_MIN / LLONG_MAX (which were causing compile errors when I ran ./build).
