### PR TITLE
Zero the enemy struct before scanning.

### DIFF
--- a/lib/mid/enemy.c
+++ b/lib/mid/enemy.c
@@ -92,6 +92,7 @@ void enemydraw(Enemy *e, Gfx *g){
 }
 
 _Bool enemyscan(char *buf, Enemy *e){
+	*e = (Enemy){};
 	int id;
 	// need to take a peek at the ID to dispatch the correct scan method.
 	if (sscanf(buf, " %d", &id) != 1)


### PR DESCRIPTION
Otherwise some of the fields may be nonesense.  How did this ever work?

Fixes #15
