### PR TITLE
Move ugly _POSIX_SOURCE and _POSIX_C_SOURCE=200112L flags to pipe_posix.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CC := clang
 LD := clang
 AR := ar
 
-MANDCFLAGS := -g -O2 -Wall -Werror -std=c99 -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200112L
+MANDCFLAGS := -g -O2 -Wall -Werror -std=c99
 MANDLDFLAGS := 
 
 ifeq ($(OS),win)

--- a/lib/os/pipe_posix.c
+++ b/lib/os/pipe_posix.c
@@ -1,5 +1,8 @@
 /* © 2013 the Mid Authors under the MIT license. See AUTHORS for the list of authors.*/
 
+#define _POSIX_SOURCE
+#define _POSIX_C_SOURCE 200112L
+
 #include <stdio.h>
 #include "../../include/os.h"
 


### PR DESCRIPTION
They are only needed for popen and pclose, so let's define them just
in the one file that uses popen and pclose. This way it's obvious why
we need to define them (because stupid GNU requires them for the
_standardized_ popen and pclose calls).
